### PR TITLE
Improve RSAPSS encoding support

### DIFF
--- a/x509-validation/Data/X509/Validation/Signature.hs
+++ b/x509-validation/Data/X509/Validation/Signature.hs
@@ -77,9 +77,7 @@ verifySignature (SignatureALG hashALG PubKeyALG_RSAPSS) pubkey cdata signature =
                else SignatureFailed SignatureInvalid
   where
     verifyF (PubKeyRSA key)
-      | hashALG == HashSHA256 = Just $
-          let params = (PSS.defaultPSSParams SHA256) { PSS.pssSaltLength = 20 }
-           in PSS.verify params key
+      | hashALG == HashSHA256 = Just $ PSS.verify (PSS.defaultPSSParams SHA256) key
       | hashALG == HashSHA384 = Just $ PSS.verify (PSS.defaultPSSParams SHA384) key
       | hashALG == HashSHA512 = Just $ PSS.verify (PSS.defaultPSSParams SHA512) key
       | hashALG == HashSHA224 = Just $ PSS.verify (PSS.defaultPSSParams SHA224) key

--- a/x509-validation/Data/X509/Validation/Signature.hs
+++ b/x509-validation/Data/X509/Validation/Signature.hs
@@ -77,7 +77,9 @@ verifySignature (SignatureALG hashALG PubKeyALG_RSAPSS) pubkey cdata signature =
                else SignatureFailed SignatureInvalid
   where
     verifyF (PubKeyRSA key)
-      | hashALG == HashSHA256 = Just $ PSS.verify (PSS.defaultPSSParams SHA256) key
+      | hashALG == HashSHA256 = Just $
+          let params = (PSS.defaultPSSParams SHA256) { PSS.pssSaltLength = 20 }
+           in PSS.verify params key
       | hashALG == HashSHA384 = Just $ PSS.verify (PSS.defaultPSSParams SHA384) key
       | hashALG == HashSHA512 = Just $ PSS.verify (PSS.defaultPSSParams SHA512) key
       | hashALG == HashSHA224 = Just $ PSS.verify (PSS.defaultPSSParams SHA224) key

--- a/x509/Data/X509/AlgorithmIdentifier.hs
+++ b/x509/Data/X509/AlgorithmIdentifier.hs
@@ -108,13 +108,21 @@ instance ASN1Object SignatureALG where
             signatureAlg -> Right (signatureAlg, xs)
     fromASN1 (Start Sequence:OID oid:End Sequence:xs) =
         Right (oidSig oid, xs)
-    fromASN1 (Start Sequence:OID [1,2,840,113549,1,1,10]:Start Sequence:Start _:Start Sequence:OID hash1:End Sequence:End _:Start _:Start Sequence:OID [1,2,840,113549,1,1,8]:Start Sequence:OID _hash2:End Sequence:End Sequence:End _:Start _: IntVal _iv: End _: End Sequence : End Sequence:xs) =
-        Right (oidSig hash1, xs)
-    fromASN1 (Start Sequence:OID [1,2,840,113549,1,1,10]:Start Sequence:Start _:Start Sequence:OID hash1:Null:End Sequence:End _:Start _:Start Sequence:OID [1,2,840,113549,1,1,8]:Start Sequence:OID _hash2:Null:End Sequence:End Sequence:End _:Start _: IntVal _iv: End _: End Sequence : End Sequence:xs) =
-        Right (oidSig hash1, xs)
+    fromASN1 (Start Sequence:OID [1,2,840,113549,1,1,10]:Start Sequence:Start _:Start Sequence:OID hash1:End Sequence:End _:Start _:Start Sequence:OID [1,2,840,113549,1,1,8]:Start Sequence:OID _hash2:End Sequence:End Sequence:End _:xs) =
+        handleRsapssSaltFromASN1 hash1 xs
+    fromASN1 (Start Sequence:OID [1,2,840,113549,1,1,10]:Start Sequence:Start _:Start Sequence:OID hash1:Null:End Sequence:End _:Start _:Start Sequence:OID [1,2,840,113549,1,1,8]:Start Sequence:OID _hash2:Null:End Sequence:End Sequence:End _:xs) =
+        handleRsapssSaltFromASN1 hash1 xs
     fromASN1 _ =
         Left "fromASN1: X509.SignatureALG: unknown format"
     toASN1 (SignatureALG_Unknown oid) = \xs -> Start Sequence:OID oid:Null:End Sequence:xs
     toASN1 signatureAlg@(SignatureALG hashAlg PubKeyALG_RSAPSS) = \xs -> Start Sequence:OID [1,2,840,113549,1,1,10]:Start Sequence:Start (Container Context 0):Start Sequence:OID (sigOID signatureAlg):End Sequence:End (Container Context 0):Start (Container Context 1): Start Sequence:OID [1,2,840,113549,1,1,8]:Start Sequence:OID (sigOID signatureAlg):End Sequence:End Sequence:End (Container Context 1):Start (Container Context 2):IntVal (saltLen hashAlg):End (Container Context 2):End Sequence:End Sequence:xs
     toASN1 signatureAlg@(SignatureALG_IntrinsicHash _) = \xs -> Start Sequence:OID (sigOID signatureAlg):End Sequence:xs
     toASN1 signatureAlg = \xs -> Start Sequence:OID (sigOID signatureAlg):Null:End Sequence:xs
+
+handleRsapssSaltFromASN1 :: OID -> [ASN1] -> Either String (SignatureALG, [ASN1])
+handleRsapssSaltFromASN1 hashOid xs = case xs of
+    Start _: IntVal _iv: End _: End Sequence : End Sequence:xs' ->
+        Right (oidSig hashOid, xs')
+    End Sequence:End Sequence:xs' ->
+        Right (oidSig hashOid, xs')
+    _ -> Left "fromASN1: X509.SignatureALG: unknown RSAPSS parameters format"

--- a/x509/Data/X509/PublicKey.hs
+++ b/x509/Data/X509/PublicKey.hs
@@ -88,7 +88,7 @@ data PubKey =
 -- End Sequence
 instance ASN1Object PubKey where
     fromASN1 (Start Sequence:Start Sequence:OID pkalg:xs)
-        | pkalg == getObjectID PubKeyALG_RSA =
+        | pkalg == getObjectID PubKeyALG_RSA || pkalg == getObjectID PubKeyALG_RSAPSS =
             case removeNull xs of
                 End Sequence:BitString bits:End Sequence:xs2 -> decodeASN1Err "RSA" bits xs2 (toPubKeyRSA . rsaPubFromASN1)
                 _ -> Left ("fromASN1: X509.PubKey: unknown RSA format: " ++ show xs)

--- a/x509/x509.cabal
+++ b/x509/x509.cabal
@@ -1,5 +1,5 @@
 Name:                x509
-version:             1.7.6
+version:             1.7.7
 Description:         X509 reader and writer. please see README
 License:             BSD3
 License-file:        LICENSE


### PR DESCRIPTION
Salt length is an optional parameter in `RSASSA-PSS-params` (see https://www.rfc-editor.org/rfc/rfc3447.html#appendix-A.2.3).   It is however implemented as required in the current `ASN1Object SignatureALG` instance.  This PR makes it optional.

Additionally, in the `ASN1Object PubKey` instance, the case of `pkalg == getObjectID PubKeyALG_RSAPSS` has no corresponding handler, which is fixed in the current PR.  Following the corresponding [signature validation code](https://github.com/haskell-tls/hs-certificate/blob/master/x509-validation/Data/X509/Validation/Signature.hs#L79), when `SignatureALG` contains `PubKeyALG_RSAPSS`, the corresponding public key is represented as `PubKeyRSA`.